### PR TITLE
Implement operators and equality comparison in Point and Size

### DIFF
--- a/ConsoleGameLib/CoreTypes/Point.cs
+++ b/ConsoleGameLib/CoreTypes/Point.cs
@@ -15,5 +15,39 @@ namespace ConsoleGameLib.CoreTypes
 
         public int X;
         public int Y;
+
+        public override int GetHashCode()
+        {
+            // Uses http://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 37;
+                hash = hash * 67 + X.GetHashCode();
+                hash = hash * 67 + Y.GetHashCode();
+                return hash;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || !(obj is Point))
+            {
+                return false;
+            }
+            Point oth = (Point)obj;
+            return X == oth.X && Y == oth.Y;
+        }
+
+        public static bool operator ==(Point left, Point right)
+        {
+            // Struct, so no need for null check
+            return left.X == right.X && left.Y == right.Y;
+        }
+
+        public static bool operator !=(Point left, Point right)
+        {
+            // Struct, so no need for null check
+            return left.X != right.X || left.Y != right.Y;
+        }
     }
 }

--- a/ConsoleGameLib/CoreTypes/Point.cs
+++ b/ConsoleGameLib/CoreTypes/Point.cs
@@ -64,5 +64,15 @@ namespace ConsoleGameLib.CoreTypes
         {
             return new Point(-unary.X, -unary.Y);
         }
+
+        public static Point operator *(Point point, int scalar)
+        {
+            return new Point(point.X * scalar, point.Y * scalar);
+        }
+
+        public static Point operator /(Point point, int scalar)
+        {
+            return new Point(point.X / scalar, point.Y / scalar);
+        }
     }
 }

--- a/ConsoleGameLib/CoreTypes/Point.cs
+++ b/ConsoleGameLib/CoreTypes/Point.cs
@@ -49,5 +49,20 @@ namespace ConsoleGameLib.CoreTypes
             // Struct, so no need for null check
             return left.X != right.X || left.Y != right.Y;
         }
+
+        public static Point operator +(Point left, Point right)
+        {
+            return new Point(left.X + right.X, left.Y + right.Y);
+        }
+
+        public static Point operator -(Point left, Point right)
+        {
+            return new Point(left.X - right.X, left.Y - right.Y);
+        }
+
+        public static Point operator -(Point unary)
+        {
+            return new Point(-unary.X, -unary.Y);
+        }
     }
 }

--- a/ConsoleGameLib/CoreTypes/Size.cs
+++ b/ConsoleGameLib/CoreTypes/Size.cs
@@ -15,5 +15,39 @@ namespace ConsoleGameLib.CoreTypes
 
         public int Width;
         public int Height;
+
+        public override int GetHashCode()
+        {
+            // Uses http://stackoverflow.com/questions/263400/what-is-the-best-algorithm-for-an-overridden-system-object-gethashcode
+            unchecked // Overflow is fine, just wrap
+            {
+                int hash = 29;
+                hash = hash * 89 + Width.GetHashCode();
+                hash = hash * 89 + Height.GetHashCode();
+                return hash;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null || !(obj is Size))
+            {
+                return false;
+            }
+            Size oth = (Size)obj;
+            return Width == oth.Width && Height == oth.Height;
+        }
+
+        public static bool operator ==(Size left, Size right)
+        {
+            // Struct, so no need for null check
+            return left.Width == right.Width && left.Height == right.Height;
+        }
+
+        public static bool operator !=(Size left, Size right)
+        {
+            // Struct, so no need for null check
+            return left.Width != right.Width || left.Height != right.Height;
+        }
     }
 }

--- a/ConsoleGameLib/CoreTypes/Size.cs
+++ b/ConsoleGameLib/CoreTypes/Size.cs
@@ -49,5 +49,15 @@ namespace ConsoleGameLib.CoreTypes
             // Struct, so no need for null check
             return left.Width != right.Width || left.Height != right.Height;
         }
+
+        public static Size operator +(Size left, Size right)
+        {
+            return new Size(left.Width + right.Width, left.Height + right.Height);
+        }
+
+        public static Size operator -(Size left, Size right)
+        {
+            return new Size(left.Width - right.Width, left.Height - right.Height);
+        }
     }
 }

--- a/ConsoleGameLib/CoreTypes/Size.cs
+++ b/ConsoleGameLib/CoreTypes/Size.cs
@@ -59,5 +59,15 @@ namespace ConsoleGameLib.CoreTypes
         {
             return new Size(left.Width - right.Width, left.Height - right.Height);
         }
+
+        public static Size operator *(Size point, int scalar)
+        {
+            return new Size(point.Width * scalar, point.Height * scalar);
+        }
+
+        public static Size operator /(Size point, int scalar)
+        {
+            return new Size(point.Width / scalar, point.Width / scalar);
+        }
     }
 }


### PR DESCRIPTION
Currently, the core types `Point` and `Size` do not have equality or operators implemented. This PR fixes that. This overrides equality, inequality, addition, subtraction, and unary negation on `Point`, and all of those except unary negation on `Size`. The `Equals` and `GetHashCode` methods are also implemented, with hash codes using [the method recommended by Jon Skeet](http://stackoverflow.com/a/263416). These changes will allow cleaner code, such as some of the equality checks in PR #1.

While reviewing this code, I noticed that Size will happily accept negative values for `Width` and `Height`. Is this my design? If so, it is not commented, and it should be because it seems contrary to intuition. If not, it should probably be rewritten as a property that validates positive values for both properties. Any thoughts on this?